### PR TITLE
Added ability to use beta api, intergrated 5 options

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,14 @@ var request = require('request');
 
 module.exports = url2png;
 
-function url2png(apiKey, privateKey) {
+function url2png(apiKey, privateKey, type) {
     var prefix = '//api.url2png.com/v6/';
     var format = 'png'
     var lib = {};
+
+    if(type == 'beta'){
+        prefix = '//beta.url2png.com/v6/';
+    }
 
     function buildURL(url, options) {
         options = options || {};
@@ -17,6 +21,11 @@ function url2png(apiKey, privateKey) {
         if(options.delay && typeof options.delay !== 'number') throw new Error('delay should be a number in seconds');
         if(options.force && typeof options.force !== 'boolean') throw new Error('force should be a boolean');
         if(options.protocol && options.protocol != 'https' && options.protocol != 'http') throw new Error('protocol should either be "https" or "http"');
+        if(options.user_agent && typeof options.user_agent !== 'string') throw new Error('user_agent should be user agent string');
+        if(options.unique && typeof options.unique !== 'string') throw new Error('unique should be a string');
+        if(options.accept_languages && typeof options.accept_languages !== 'string') throw new Error('accept_languages should be a string');
+        if(options.ttl && typeof options.ttl !== 'number') throw new Error('ttl should be a number');
+        if(options.custom_css_url && typeof options.custom_css_url !== 'string') throw new Error('custom_css_url should be a string');
         options.protocol = options.protocol || '';
 
         url = 'url=' + encodeURIComponent(url);


### PR DESCRIPTION
Beta API provides better website rendering.
With the current API I sometimes run into svg issues even though it renders correctly on even IE 9.

To use simply add the 'beta' string at the end
`var url2png = require('url2png')('API_KEY', 'PRIVATE_KEY', 'beta');`


Integrated 5 options 'user_agent', 'unique', 'accept_languages', 'ttl' and 'custom_css_url'.

Current know issues with both the current + beta API's:
When either the 'user_agent' or 'accept_languages' is specified it will only accept url's with out 'http/https' and without a subdirectory. Else it will throw a 500 error and return this -
<img width="982" alt="screen shot 2016-10-31 at 5 50 07 am" src="https://cloud.githubusercontent.com/assets/22234532/19850268/033e1d82-9f2e-11e6-8c64-29300e422ae9.png">

Reaching out to support to see if they can help resolve that issue.
