### PR TITLE
added default protocol for buildUrl method

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ var screenshotStream = url2png.readURL(url, options);
       <td>protocol</td>
       <td>string</td>
       <td>-</td>
-      <td>The protocol to use, can be 'https' or 'http' (blank to use protocol relative urls).</td>
+      <td>The protocol to use, can be 'https' or 'http'. Default 'https'.</td>
     </tr>
   </tbody>
 </table>

--- a/index.js
+++ b/index.js
@@ -10,18 +10,18 @@ function url2png(apiKey, privateKey) {
 
     function buildURL(url, options) {
         options = options || {};
-        if(typeof url !== 'string') throw new Error('url should be of type string (something like www.google.com)');
-        if(options.viewport && (typeof options.viewport !== 'string' || !options.viewport.match(/\d+x\d+/))) throw new Error('viewport should be a string with the format "{width}x{height}"');
-        if(options.fullpage && typeof options.fullpage !== 'boolean') throw new Error('fullpage should be a boolean');
-        if(options.thumbnail_max_width && typeof options.thumbnail_max_width !== 'number') throw new Error('thumbnail_max_width should be a number in pixels');
-        if(options.delay && typeof options.delay !== 'number') throw new Error('delay should be a number in seconds');
-        if(options.force && typeof options.force !== 'boolean') throw new Error('force should be a boolean');
-        if(options.protocol && options.protocol != 'https' && options.protocol != 'http') throw new Error('protocol should either be "https" or "http"');
-        options.protocol = options.protocol || '';
+        if (typeof url !== 'string') throw new Error('url should be of type string (something like www.google.com)');
+        if (options.viewport && (typeof options.viewport !== 'string' || !options.viewport.match(/\d+x\d+/))) throw new Error('viewport should be a string with the format "{width}x{height}"');
+        if (options.fullpage && typeof options.fullpage !== 'boolean') throw new Error('fullpage should be a boolean');
+        if (options.thumbnail_max_width && typeof options.thumbnail_max_width !== 'number') throw new Error('thumbnail_max_width should be a number in pixels');
+        if (options.delay && typeof options.delay !== 'number') throw new Error('delay should be a number in seconds');
+        if (options.force && typeof options.force !== 'boolean') throw new Error('force should be a boolean');
+        if (options.protocol && options.protocol != 'https' && options.protocol != 'http') throw new Error('protocol should either be "https" or "http"');
+        options.protocol = options.protocol || 'https';
 
         url = 'url=' + encodeURIComponent(url);
         var optionsQuery = '';
-        for(var option in options) {
+        for (var option in options) {
             if (option != 'protocol')
                 optionsQuery += "&" + [option, options[option]].join('=');
         }

--- a/package.json
+++ b/package.json
@@ -1,36 +1,32 @@
 {
-  "name": "url2png",
-  "version": "6.0.2",
-  "description": "node.js API for the URL2PNG online service",
-  "main": "index.js",
-  "dependencies": {
-    "request": ">=2.53.0 <3.0.0"
-  },
-  "devDependencies": {},
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ForbesLindesay/url2png.git"
-  },
-  "keywords": [
-    "url2png",
-    "url",
-    "png",
-    "websnapr",
-    "shrinktheweb",
-    "thumbalizr",
-    "webthumb",
-    "browsershots",
-    "cutycapt"
-  ],
-  "author": {
-    "name": "Forbes Lindesay"
-  },
-  "contributors": [
-    { "name": "Pato Jutard", "email": "pato@mural.ly" },
-    { "name": "Johnny Halife", "email": "johnny@mural.ly" }
-  ],
-  "license": "BSD"
+    "name": "@mpurusottamc/url2png",
+    "version": "6.0.3",
+    "description": "node.js API for the URL2PNG online service",
+    "main": "index.js",
+    "dependencies": {
+        "request": ">=2.53.0 <3.0.0"
+    },
+    "devDependencies": {},
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mpurusottamc/url2png.git"
+    },
+    "keywords": [
+        "url2png",
+        "url",
+        "png",
+        "websnapr",
+        "shrinktheweb",
+        "thumbalizr",
+        "webthumb",
+        "browsershots",
+        "cutycapt"
+    ],
+    "author": {
+        "name": "Purusottam Mupunu"
+    },
+    "license": "BSD"
 }


### PR DESCRIPTION
if the protocol is not passed in options, the generated url from buildUrl does not contain any protocol. This checkin assigns a default protocol (https) in the buildUrl method.